### PR TITLE
NDS-261: Storage quotas

### DIFF
--- a/FILES.deploy-tools/root/group_vars/cluster.yml
+++ b/FILES.deploy-tools/root/group_vars/cluster.yml
@@ -1,0 +1,3 @@
+---
+clusterfs_vol_name: "global"
+clusterfs_vol_path: "/var/glfs/global"

--- a/FILES.deploy-tools/root/group_vars/glfs.yml
+++ b/FILES.deploy-tools/root/group_vars/glfs.yml
@@ -1,3 +1,2 @@
 ---
 k8_initial_labels: "ndslabs-node-role=glfs"
-clusterfs_vol_name: "global"

--- a/FILES.deploy-tools/root/group_vars/nodes.yml
+++ b/FILES.deploy-tools/root/group_vars/nodes.yml
@@ -1,4 +1,2 @@
 ---
 k8_initial_labels: "ndslabs-node-role=compute"
-clusterfs_vol_path: "/var/glfs/global"
-clusterfs_vol_name: "global"

--- a/FILES.deploy-tools/root/inventory/HA
+++ b/FILES.deploy-tools/root/inventory/HA
@@ -12,7 +12,6 @@ kube_version=1.2.4
 kube-ui=true                                          
 kube-dash=true
 key_name={{logical_cluster_name}}
-cluster_fs_hostpath=/media/glfs 
 
 [compute:vars]
 flavor=n-rc1.large

--- a/FILES.deploy-tools/root/inventory/minimal-for-testing
+++ b/FILES.deploy-tools/root/inventory/minimal-for-testing
@@ -9,7 +9,6 @@ image=CoreOSAlpha
 flavor=m1.medium
 kube_version=1.2.4
 key_name={{logical_cluster_name}}
-cluster_fs_hostpath=/media/glfs 
 ndslabs_domain= {{logical_cluster_name}}.ndslabs.org
 
 #

--- a/FILES.deploy-tools/root/inventory/single-node-dev
+++ b/FILES.deploy-tools/root/inventory/single-node-dev
@@ -9,7 +9,6 @@ image=CoreOSAlpha
 flavor=m1.small
 kube_version=1.2.4
 key_name={{logical_cluster_name}}
-cluster_fs_hostpath=/media/glfs 
 ndslabs_domain= {{logical_cluster_name}}
 
 #

--- a/FILES.deploy-tools/root/playbooks/ndslabs-k8.yml
+++ b/FILES.deploy-tools/root/playbooks/ndslabs-k8.yml
@@ -120,7 +120,7 @@
 - name: NDSLabs GLFS Cluster FileSystem Clients
   hosts: compute
   roles:
-    - { role: k8-glfs-client-set, when: "'glfs' in group_names" }
+    - { role: k8-glfs-client-set, when: "groups['glfs']|length > 0" }
     
 # Import TLS certs as kubernetes secrets
 - name: Create TLS secret

--- a/FILES.deploy-tools/usr/local/lib/ndslabs/ansible/roles/k8-glfs-server-pods/tasks/main.yml
+++ b/FILES.deploy-tools/usr/local/lib/ndslabs/ansible/roles/k8-glfs-server-pods/tasks/main.yml
@@ -80,3 +80,9 @@
   delegate_to: "{{ groups['masters'][0] }}"                                                                                                 
   run_once: true                                                                                                                            
   when: fcreated.changed
+
+- name: Gluster enable quota
+  command: "kubectl exec -it {{ glpod }} gluster volume quota {{ clusterfs_vol_name }} enable"
+  delegate_to: "{{ groups['masters'][0] }}"
+  run_once: true 
+  when: fcreated.changed

--- a/FILES.deploy-tools/usr/local/lib/ndslabs/ansible/roles/ndslabs-api-gui/templates/ndslabs-apiserver.yaml.j2
+++ b/FILES.deploy-tools/usr/local/lib/ndslabs/ansible/roles/ndslabs-api-gui/templates/ndslabs-apiserver.yaml.j2
@@ -53,9 +53,11 @@ spec:
             value: "{{ndslabs_domain}}"
           - name: VOLUME_PATH
             value: "/ndslabs/data/volumes"
+          - name: VOLUME_NAME
+            value: "{{ clusterfs_vol_name }} "
       volumes:
        - hostPath:
-            path: /ndslabs/data/volumes
+            path: {{ clusterfs_vol_path }}
          name: volumes
       nodeSelector:
           ndslabs-node-role: compute

--- a/FILES.deploy-tools/usr/local/lib/ndslabs/ansible/roles/ndslabs-api-gui/templates/ndslabs-apiserver.yaml.j2
+++ b/FILES.deploy-tools/usr/local/lib/ndslabs/ansible/roles/ndslabs-api-gui/templates/ndslabs-apiserver.yaml.j2
@@ -35,7 +35,7 @@ spec:
           protocol: TCP
         volumeMounts:
           - name: volumes
-            mountPath: /ndslabs/data/volumes
+            mountPath: {{ clusterfs_vol_path }}
         env:
           - name: ETCD_ADDR
             value: "{{ ansible_default_ipv4.address }}:2379"
@@ -52,7 +52,7 @@ spec:
           - name: DOMAIN
             value: "{{ndslabs_domain}}"
           - name: VOLUME_PATH
-            value: "/ndslabs/data/volumes"
+            value: "{{ clusterfs_vol_path }}"
           - name: VOLUME_NAME
             value: "{{ clusterfs_vol_name }} "
       volumes:

--- a/FILES.deploy-tools/usr/local/lib/ndslabs/ansible/roles/ndslabs-api-gui/templates/ndslabs-webui.yaml.j2
+++ b/FILES.deploy-tools/usr/local/lib/ndslabs/ansible/roles/ndslabs-api-gui/templates/ndslabs-webui.yaml.j2
@@ -42,7 +42,7 @@ spec:
           - name: APISERVER_PATH
             value: "/api"
           - name: APISERVER_SECURE
-            value: "false"
+            value: "true"
           - name: UI_BASE_PATH
             value: ""
         readinessProbe:


### PR DESCRIPTION
The main change for this PR is to enable GFS quotas on the global volume.  Other changes include:
- Moving clusterfs_vol_name and clusterfs_vol_path variables to new cluster.yml so the values can be used on compute nodes (e.g., apiserver)
- Adding clusterfs_vol_name and clusterfs_vol_path to apiserver.yaml template
- Fixed a problem with the GFS client deploy on multinode system in playbook
- Enabling secure API server in GUI config
