### PR TITLE
NDS-554: Indicate when API server can't be reached

### DIFF
--- a/FILES.deploy-tools/usr/local/lib/ndslabs/ansible/roles/ndslabs-api-gui/templates/ndslabs-webui.yaml.j2
+++ b/FILES.deploy-tools/usr/local/lib/ndslabs/ansible/roles/ndslabs-api-gui/templates/ndslabs-webui.yaml.j2
@@ -43,6 +43,8 @@ spec:
             value: "/api"
           - name: APISERVER_SECURE
             value: "true"
+          - name: SUPPORT_EMAIL
+            value: "{{ support_email }}"
         readinessProbe:
           httpGet:
             path: /asset/png/favicon-2-32x32.png


### PR DESCRIPTION
Substitute SUPPORT_EMAIL into NDS Labs webui when deploying new clusters
