### PR TITLE
NDS-642: Restrict ingress protocols to TLSv1.2, per Qualys report.

### DIFF
--- a/FILES.deploy-tools/usr/local/lib/ndslabs/ansible/roles/ndslabs-loadbalancer/templates/loadbalancer.yaml.j2
+++ b/FILES.deploy-tools/usr/local/lib/ndslabs/ansible/roles/ndslabs-loadbalancer/templates/loadbalancer.yaml.j2
@@ -1,6 +1,7 @@
 apiVersion: v1
 data:
   server-name-hash-bucket-size: "512"
+  ssl-protocol: "TLSv1.2"
 kind: ConfigMap
 metadata:
   name: nginx-ingress-conf


### PR DESCRIPTION
See https://opensource.ncsa.illinois.edu/jira/browse/NDS-642