### PR TITLE
NDS-559: Console times out too quickly

### DIFF
--- a/FILES.deploy-tools/usr/local/lib/ndslabs/ansible/roles/ndslabs-loadbalancer/templates/loadbalancer.yaml.j2
+++ b/FILES.deploy-tools/usr/local/lib/ndslabs/ansible/roles/ndslabs-loadbalancer/templates/loadbalancer.yaml.j2
@@ -2,6 +2,8 @@ apiVersion: v1
 data:
   server-name-hash-bucket-size: "512"
   ssl-protocols: "TLSv1.2"
+  proxy-read-timeout: "300"
+  proxy-send-timeout: "300"
 kind: ConfigMap
 metadata:
   name: nginx-ingress-conf


### PR DESCRIPTION
* Added 5 minute proxy timeout for websockets