### PR TITLE
NDS-994/976: Fix /media/storage in deploy-tools and nginx body-size

### DIFF
--- a/inventory/group_vars/cluster.yml
+++ b/inventory/group_vars/cluster.yml
@@ -7,6 +7,5 @@ clusterfs_vol_config: "replica 2 transport tcp"
 cluster_name: cluster.local
 cert_name: "{{ logical_cluster_name }}"
 
-docker_volume_gb: 40
-storage_volume_gb: 20
+storage_volume_gb: 100
 

--- a/playbooks/openstack-provision.yml
+++ b/playbooks/openstack-provision.yml
@@ -70,18 +70,18 @@
   roles:
     - coreos-ndslabs-devsystem
 
-# Provision and attach OpenStack volume for /var/lib/docker
-- name: OpenStack docker provision volume and attach
-  hosts: compute:&openstack:&coreos
-  roles: 
-    - { role: openstack-volume-mount, volume_name: 'dockervol', volume_size: "{{ docker_volume_gb }}", mount_point: '/var/lib/docker', filesystem_format: 'xfs' }
-    
 # Provision and attach OpenStack volume for /media/storage
 - name: OpenStack provision storage volume and attach
   hosts: all:&openstack:&coreos
   
   roles: 
     - { role: openstack-volume-mount, volume_name: 'storagevol', volume_size: "{{ storage_volume_gb }}", mount_point: '/media/storage', filesystem_format: 'xfs' }
+
+# Bind mount /var/lib/docker from storage volume
+- name: Bind mount /var/lib/docker for all nodes
+  hosts: all:&coreos
+  roles:
+    - { role: storage-volume-bind-mount, name: var-lib-docker.mount, src: /var/lib/docker, dest: /media/storage, dir_name: docker }
 
 # Bind mount /var/log from storage volume
 - name: Bind mount /var/log for all nodes

--- a/roles/ndslabs-loadbalancer/templates/loadbalancer.yaml.j2
+++ b/roles/ndslabs-loadbalancer/templates/loadbalancer.yaml.j2
@@ -4,6 +4,7 @@ data:
   ssl-protocols: "TLSv1.2"
   proxy-read-timeout: "300"
   proxy-send-timeout: "300"
+  body-size: 50m
 kind: ConfigMap
 metadata:
   name: nginx-ingress-conf


### PR DESCRIPTION
* Removed docker_volume_gb variable
* Bind-mount /var/lib/docker to /media/storage (instead of separate volume)
* NDS-976: Added NGINX body-size parameter to ILB