### PR TITLE
NDS-1104: Deploy-tools for Jetstream/ETK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM fedora:25
 #
 # Setup ansible and openstack cli, some convenience pkgs
 # 
-RUN dnf -y update && dnf -y install python-openstackclient wget curl rsync \
+RUN dnf -y update && dnf -y install python-openstackclient python-novaclient  wget curl rsync \
 	subversion nano openssh-clients ansible python2-shade findutils &&\
     (mkdir -p /usr/local/lib/kubernetes/contrib && cd /usr/local/lib/kubernetes/contrib &&\ 
 	svn -q checkout https://github.com/nds-org/ndslabs-kubernetes-contrib.git/branches/ndslabs-1.5.2/ansible &&\
@@ -10,7 +10,7 @@ RUN dnf -y update && dnf -y install python-openstackclient wget curl rsync \
 	    dnf -y clean all
 
 # Upgrade shade library (required to "nat_destination" errors)
-RUN pip install shade==1.8.0
+RUN pip install shade==1.8.0 python-novaclient==3.3.3 odfpy openpyxl xlrd xlwt 
 
 WORKDIR /root
 

--- a/inventory/site_vars/ncsa.yml
+++ b/inventory/site_vars/ncsa.yml
@@ -19,4 +19,6 @@ flavor_large: m4.large     # 80GdiskG disk 64Gmem 24cpu
 
 smtp_host: smtp.ncsa.uiuc.edu
 smtp_tls: true
+mtu: 1454
 
+network_name: workbench

--- a/inventory/site_vars/ncsa.yml
+++ b/inventory/site_vars/ncsa.yml
@@ -22,3 +22,5 @@ smtp_tls: true
 mtu: 1454
 
 network_name: workbench
+
+site_name: ncsa

--- a/inventory/site_vars/sdsc.yml
+++ b/inventory/site_vars/sdsc.yml
@@ -10,3 +10,6 @@ ndslabs_domain: "{{ logical_cluster_name }}.sdsc.ndslabs.org" # ???
  
 smtp_host: smtp.sdsc.edu
 smtp_tls: false
+mtu: 1458
+
+network_name: workbench

--- a/inventory/site_vars/sdsc.yml
+++ b/inventory/site_vars/sdsc.yml
@@ -13,3 +13,5 @@ smtp_tls: false
 mtu: 1458
 
 network_name: workbench
+
+site_name: sdsc

--- a/inventory/site_vars/tacc.yml
+++ b/inventory/site_vars/tacc.yml
@@ -8,11 +8,6 @@ native_dns: utexas.edu
 
 ndslabs_domain: "{{ logical_cluster_name }}.ndslabs.org" 
  
-smtp_host: ''
-smtp_port: ''
-smtp_tls: true
-gmail_user: ''
-gmail_password: ''
 mtu: 8960
 
 network_name: workbench

--- a/inventory/site_vars/tacc.yml
+++ b/inventory/site_vars/tacc.yml
@@ -1,0 +1,18 @@
+---
+
+flavor_small: m1.small              # 20G disk, 8G ram, 2cpu
+flavor_medium: m1.medium           # 20G disk, 16Gram, 8cpu
+flavor_large: m1.large            # 20G disk, 64Gram, 16cpu
+
+native_dns: utexas.edu
+
+ndslabs_domain: "{{ logical_cluster_name }}.ndslabs.org" 
+ 
+smtp_host: ''
+smtp_port: ''
+smtp_tls: true
+gmail_user: ''
+gmail_password: ''
+mtu: 8960
+
+network_name: workbench

--- a/inventory/site_vars/tacc.yml
+++ b/inventory/site_vars/tacc.yml
@@ -16,3 +16,5 @@ gmail_password: ''
 mtu: 8960
 
 network_name: workbench
+
+site_name: tacc

--- a/inventory/site_vars/tacc.yml
+++ b/inventory/site_vars/tacc.yml
@@ -7,7 +7,9 @@ flavor_large: m1.large            # 20G disk, 64Gram, 16cpu
 native_dns: utexas.edu
 
 ndslabs_domain: "{{ logical_cluster_name }}.ndslabs.org" 
- 
+
+smtp_host: ''
+smtp_port: ''
 mtu: 8960
 
 network_name: workbench

--- a/playbooks/k8s-install.yml
+++ b/playbooks/k8s-install.yml
@@ -37,12 +37,13 @@
   roles:
     - ndslabs-k8-init-labels
 
+- name: Docker log rotation
+  hosts: cluster
+  roles:
+    - docker-log-rotation
+
 - name: Fix flannel mtu
   hosts: coreos
   roles:
     - flannel-mtu
 
-- name: Docker log rotation
-  hosts: cluster
-  roles:
-    - docker-log-rotation

--- a/playbooks/k8s-install.yml
+++ b/playbooks/k8s-install.yml
@@ -37,3 +37,7 @@
   roles:
     - ndslabs-k8-init-labels
 
+- name: Fix flannel mtu
+  hosts: coreos
+  roles:
+    - flannel-mtu

--- a/playbooks/k8s-install.yml
+++ b/playbooks/k8s-install.yml
@@ -41,3 +41,8 @@
   hosts: coreos
   roles:
     - flannel-mtu
+
+- name: Docker log rotation
+  hosts: cluster
+  roles:
+    - docker-log-rotation

--- a/playbooks/ndslabs-k8s-install.yml
+++ b/playbooks/ndslabs-k8s-install.yml
@@ -55,7 +55,7 @@
   connection: local
   tasks:
     - os_floating_ip: server={{ logical_cluster_name }}-{{ inventory_hostname }} reuse=yes wait=yes
-    - command: nova add-secgroup {{ logical_cluster_name }}-{{ inventory_hostname }} {{ security_groups }}
+    - command: openstack server add security group {{ logical_cluster_name }}-{{ inventory_hostname }} {{ security_groups }}
 
 
 # Create or reuse existing TLS certs

--- a/playbooks/openstack-delete.yml
+++ b/playbooks/openstack-delete.yml
@@ -40,7 +40,6 @@
   connection: local
   tasks:
     - os_volume: state=absent wait=yes display_name="{{ logical_cluster_name }}-{{ inventory_hostname }}-storagevol"
-    - os_volume: state=absent wait=yes display_name="{{ logical_cluster_name }}-{{ inventory_hostname }}-bootvol"
 
 # delete glfs vols
 - name: Remove glfs volumes

--- a/playbooks/openstack-provision.yml
+++ b/playbooks/openstack-provision.yml
@@ -82,6 +82,7 @@
   hosts: all:&coreos
   roles:
     - { role: storage-volume-bind-mount, name: var-lib-docker.mount, src: /var/lib/docker, dest: /media/storage, dir_name: docker }
+    - var-lib-docker
 
 # Bind mount /var/log from storage volume
 - name: Bind mount /var/log for all nodes

--- a/roles/coreos-ndslabs-devsystem/tasks/main.yml
+++ b/roles/coreos-ndslabs-devsystem/tasks/main.yml
@@ -12,12 +12,21 @@
   become: true
   systemd: name=locksmithd state=stopped masked=yes
 
+- name: Update MTU
+  become: true
+  template: src=10-net.rules.j2 dest=/etc/udev/rules.d/10-net.rules
+
+- name: notify systemd of MTU change
+  become: true
+  command: systemctl restart systemd-udev-trigger.service
+
 - name: fix coreos docker BIP and MTU - make service dir
   become: true
   file: path=/etc/systemd/system/docker.service.d state=directory
+
 - name: fix coreos BIP and MTU - copy the service file
   become: true
-  copy: src=10-docker0.conf dest=/etc/systemd/system/docker.service.d/10-docker0.conf
+  template: src=10-docker0.conf.j2 dest=/etc/systemd/system/docker.service.d/10-docker0.conf
 
 - name: Get CoreOS version
   shell: "(. /etc/os-release && echo ${VERSION}) | cut -d. -f1"
@@ -36,4 +45,3 @@
 - name: CoreOS set our timezone
   become: true
   command:  timedatectl set-timezone America/Chicago
-

--- a/roles/coreos-ndslabs-devsystem/templates/10-docker0.conf.j2
+++ b/roles/coreos-ndslabs-devsystem/templates/10-docker0.conf.j2
@@ -1,3 +1,3 @@
 [Service]
 Environment="DOCKER_OPT_BIP=--bip=10.200.0.1/16"
-Environment="DOCKER_OPT_MTU=--mtu=1454"
+Environment="DOCKER_OPT_MTU=--mtu={{ mtu }}"

--- a/roles/coreos-ndslabs-devsystem/templates/10-net.rules.j2
+++ b/roles/coreos-ndslabs-devsystem/templates/10-net.rules.j2
@@ -1,0 +1,1 @@
+ACTION=="add", SUBSYSTEM=="net", KERNEL=="eth0", ATTR{mtu}="{{ mtu }}"

--- a/roles/docker-log-rotation/files/daemon.json
+++ b/roles/docker-log-rotation/files/daemon.json
@@ -1,0 +1,8 @@
+{
+    "live-restore": true,
+    "log-driver": "json-file",
+    "log-opts": {
+      "max-size": "200m",
+      "max-file": "1"
+    }
+}

--- a/roles/docker-log-rotation/tasks/main.yml
+++ b/roles/docker-log-rotation/tasks/main.yml
@@ -3,7 +3,3 @@
 - name: Docker log rotation
   become: true
   copy: src=daemon.json dest=/etc/docker/daemon.json
-
-- name: Restart docker
-  become: true
-  command: systemctl restart docker

--- a/roles/docker-log-rotation/tasks/main.yml
+++ b/roles/docker-log-rotation/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Docker log rotation
+  become: true
+  copy: src=daemon.json dest=/etc/docker/daemon.json
+
+- name: Restart docker
+  become: true
+  command: systemctl restart docker

--- a/roles/flannel-mtu/tasks/main.yml
+++ b/roles/flannel-mtu/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+
+- name: Update flanneld service
+  become: true
+  template: src=flanneld.service.j2 dest=/etc/systemd/system/flanneld.service
+
+- name: Update flannel subnet.env
+  become: true
+  template: src=workbench-flannel.env.j2 dest=/home/core/workbench-flannel.env
+
+- name: notify flannel of MTU change
+  become: true
+  command: systemctl daemon-reload
+
+- name: Restart flanneld
+  become: true
+  command: systemctl restart flanneld
+
+- name: Restart docker
+  become: true
+  command: systemctl restart docker

--- a/roles/flannel-mtu/tasks/main.yml
+++ b/roles/flannel-mtu/tasks/main.yml
@@ -19,3 +19,6 @@
 - name: Restart docker
   become: true
   command: systemctl restart docker
+
+- name: Wait for docker
+  wait_for: path=/var/run/docker.pid

--- a/roles/flannel-mtu/templates/flanneld.service.j2
+++ b/roles/flannel-mtu/templates/flanneld.service.j2
@@ -1,0 +1,13 @@
+[Unit]
+After=network-online.target
+Wants=network-online.target
+Description=flannel is an etcd backed overlay network for containers
+
+[Service]
+Type=notify
+EnvironmentFile=/etc/sysconfig/flanneld
+ExecStart=/opt/bin/flanneld --etcd-endpoints=${FLANNEL_ETCD} --etcd-prefix=${FLANNEL_ETCD_KEY} $FLANNEL_OPTIONS
+ExecStartPost=/opt/bin/mk-docker-opts.sh -f /home/core/workbench-flannel.env -d /run/flannel/flannel_docker_opts.env -i
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/flannel-mtu/templates/workbench-flannel.env.j2
+++ b/roles/flannel-mtu/templates/workbench-flannel.env.j2
@@ -1,0 +1,4 @@
+FLANNEL_NETWORK={{ flannel_subnet }}/{{ flannel_prefix }}
+FLANNEL_SUBNET=10.100.25.1/24
+FLANNEL_MTU={{ mtu }}
+FLANNEL_IPMASQ=false

--- a/roles/ndslabs-api-gui/defaults/main.yml
+++ b/roles/ndslabs-api-gui/defaults/main.yml
@@ -9,6 +9,8 @@ spec_repo: 'https://github.com/nds-org/ndslabs-specs.git'
 spec_branch: 'master' 
 smtp_user: ''
 smtp_password: ''
+gmail_user: ''
+gmail_password: ''
 
 apiserver_image_name: ndslabs/apiserver:1.0.13
 webui_image_name: ndslabs/angular-ui:1.0.13

--- a/roles/ndslabs-api-gui/defaults/main.yml
+++ b/roles/ndslabs-api-gui/defaults/main.yml
@@ -4,6 +4,11 @@ analytics_account: ''
 support_email: ndslabs-support@nationaldataservice.org
 webui_git_dropin_repo: ''
 webui_git_dropin_branch: ''
+workbench_name: 'Labs Workbench'
+spec_repo: 'https://github.com/nds-org/ndslabs-specs.git'
+spec_branch: 'master' 
+smtp_user: ''
+smtp_password: ''
 
 apiserver_image_name: ndslabs/apiserver:1.0.13
 webui_image_name: ndslabs/angular-ui:1.0.13

--- a/roles/ndslabs-api-gui/tasks/main.yml
+++ b/roles/ndslabs-api-gui/tasks/main.yml
@@ -1,10 +1,18 @@
 - name: NDSLabs| copy yaml
   template: src="{{ item }}.j2" dest="/tmp/{{ item }}"
   with_items:
+    - ndslabs-configmap.yaml
+    - ndslabs-smtp.yaml
     - ndslabs-ingress.yaml
     - ndslabs-etcd.yaml
     - ndslabs-apiserver.yaml
     - ndslabs-webui.yaml
+
+- name: NDSLabs| create configmap
+  command: /opt/bin/kubectl apply -f "/tmp/ndslabs-configmap.yaml"
+
+- name: NDSLabs| create smtp service
+  command: /opt/bin/kubectl apply -f "/tmp/ndslabs-smtp.yaml"
 
 - name: Ingress status
   command: /opt/bin/kubectl get ing ndslabs-ingress
@@ -23,5 +31,3 @@
 
 - name: NDSLabs| create ndslabs-webui
   command: /opt/bin/kubectl apply -f "/tmp/ndslabs-webui.yaml"
-
-

--- a/roles/ndslabs-api-gui/templates/ndslabs-apiserver.yaml.j2
+++ b/roles/ndslabs-api-gui/templates/ndslabs-apiserver.yaml.j2
@@ -41,24 +41,41 @@ spec:
             value: "https://{{ ansible_default_ipv4.address }}:443"
           - name: CORS_ORIGIN_ADDR
             value: "https://www.{{ ndslabs_domain }}"
-          - name: SPEC_GIT_REPO
-            value: "https://github.com/nds-org/ndslabs-specs.git"
-          - name: SPEC_GIT_BRANCH
-            value: "master"
           - name: INGRESS
             value: "LoadBalancer"
-          - name: DOMAIN
-            value: "{{ ndslabs_domain }}"
           - name: VOLUME_PATH
             value: "{{ clusterfs_vol_path }}"
           - name: VOLUME_NAME
             value: "{{ clusterfs_vol_name }}"
-          - name: SUPPORT_EMAIL
-            value: "{{ support_email }}"
           - name: SMTP_HOST
-            value: "{{ smtp_host }}"
+            value: "$(NDSLABS_SMTP_SERVICE_HOST)"
           - name: SMTP_TLS
-            value: "{{ smtp_tls | bool | lower }}"
+            value: "false"
+          - name: SUPPORT_EMAIL
+            valueFrom:
+              configMapKeyRef:
+                name: ndslabs-config
+                key: workbench.support_email
+          - name: REQUIRE_APPROVAL
+            valueFrom:
+              configMapKeyRef:
+                name: ndslabs-config
+                key: workbench.require_account_approval
+          - name: DOMAIN
+            valueFrom:
+              configMapKeyRef:
+                name: ndslabs-config
+                key: workbench.domain
+          - name: SPEC_GIT_REPO
+            valueFrom:
+              configMapKeyRef:
+                name: ndslabs-config
+                key: git.spec_repo
+          - name: SPEC_GIT_BRANCH
+            valueFrom:
+              configMapKeyRef:
+                name: ndslabs-config
+                key: git.spec_branch
       volumes:
        - hostPath:
             path: {{ clusterfs_vol_path }}

--- a/roles/ndslabs-api-gui/templates/ndslabs-configmap.yaml.j2
+++ b/roles/ndslabs-api-gui/templates/ndslabs-configmap.yaml.j2
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ndslabs-config
+  namespace: default
+data:
+  # Enable TLS (HTTPS)?
+  tls.enable: "true"
+
+  # Customize this instance of Workbench
+  workbench.domain: "{{ ndslabs_domain }}"
+  workbench.name: "{{ workbench_name }}"
+  workbench.support_email: "{{ support_email }}"
+  workbench.analytics_tracking_id: "{{ analytics_account }}"
+
+  # Drop-in a customized Workbench UI
+  git.dropin_repo: "{{ webui_git_dropin_branch }}"
+  git.dropin_branch: "{{ webui_git_dropin_repo }}"
+
+  # Customize your Workbench catalogs
+  git.spec_repo: "{{ spec_git_repo }}"
+  git.spec_branch: "{{ spec_git_branch }}"
+
+  # To enable account approval, you need to configure the SMTP relay to use your GMail account to relay e-mails
+  # See https://support.google.com/accounts/answer/185833?hl=en
+  workbench.require_account_approval: "true"
+
+  # If using a local smtp server, use the following. The defaults will only work for NCSA nebula VMs
+  smtp.host: "{{ smtp_host }}"
+  smtp.port: "{{ smtp_port }}"
+
+  # FIXME: this is probably insecure, and should likely be using a secret instead
+  # If using gmail as your SMTP service, use the following. If using 2-factor
+  # auth see https://support.google.com/accounts/answer/185833?hl=en
+  smtp.gmail_user: "{{ gmail_user }}"
+  smtp.gmail_pass: "{{ gmail_password }}"

--- a/roles/ndslabs-api-gui/templates/ndslabs-smtp.yaml.j2
+++ b/roles/ndslabs-api-gui/templates/ndslabs-smtp.yaml.j2
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ndslabs-smtp
+spec:
+  ports:
+  - name: client-port
+    port: 25
+    protocol: TCP
+    targetPort: 25
+  selector:
+    component: ndslabs-smtp
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: ndslabs-smtp
+  labels:
+    component: ndslabs-smtp
+spec:
+  replicas: 1
+  selector:
+    component: ndslabs-smtp
+  template:
+    metadata:
+      labels:
+        component: ndslabs-smtp
+    spec:
+      containers:
+      - image: namshi/smtp
+        name: ndslabs-smtp
+        ports:
+        - containerPort: 25
+          name: server
+          protocol: TCP
+        env:
+          - name: GMAIL_USER
+            valueFrom:
+              configMapKeyRef:
+                name: ndslabs-config
+                key: smtp.gmail_user
+          - name: GMAIL_PASSWORD
+            valueFrom:
+              configMapKeyRef:
+                name: ndslabs-config
+                key: smtp.gmail_pass
+      restartPolicy: Always

--- a/roles/ndslabs-api-gui/templates/ndslabs-webui.yaml.j2
+++ b/roles/ndslabs-api-gui/templates/ndslabs-webui.yaml.j2
@@ -39,16 +39,36 @@ spec:
             value: ""
           - name: APISERVER_PATH
             value: "/api"
+          - name: DOMAIN
+            valueFrom:
+              configMapKeyRef:
+                name: ndslabs-config
+                key: workbench.domain
           - name: APISERVER_SECURE
-            value: "true"
-          - name: SUPPORT_EMAIL
-            value: "{{ support_email }}"
+            valueFrom:
+              configMapKeyRef:
+                name: ndslabs-config
+                key: tls.enable
           - name: ANALYTICS_ACCOUNT
-            value: "{{ analytics_account }}"
+            valueFrom:
+              configMapKeyRef:
+                name: ndslabs-config
+                key: workbench.analytics_tracking_id
+          - name: SUPPORT_EMAIL
+            valueFrom:
+              configMapKeyRef:
+                name: ndslabs-config
+                key: workbench.support_email
           - name: GIT_DROPIN_REPO
-            value: "{{ webui_git_dropin_repo }}"
+            valueFrom:
+              configMapKeyRef:
+                name: ndslabs-config
+                key: git.dropin_repo
           - name: GIT_DROPIN_BRANCH
-            value: "{{ webui_git_dropin_branch }}"
+            valueFrom:
+              configMapKeyRef:
+                name: ndslabs-config
+                key: git.dropin_branch
         readinessProbe:
           httpGet:
             path: /asset/png/favicon-2-32x32.png

--- a/roles/openstack-storage-volume/tasks/main.yml
+++ b/roles/openstack-storage-volume/tasks/main.yml
@@ -27,16 +27,16 @@
 - set_fact:  storage_volume_dev="{{ storage_vol_attach.attachments[0].device }}"
   when: storagevol.changed
 
-# Format storage volume with xfs
+# Format storage volume with ext4
 - name: Format storage volume
   become: true
-  filesystem: fstype=xfs dev="{{ storage_volume_dev }}"
+  filesystem: fstype=ext4 dev="{{ storage_volume_dev }}"
   when: storagevol.changed
 
 # Create systemd entries for XFS storage mount
 - name: create storage volume mount service for systemd
   become: true
-  template: src=xfs-mount.service.j2 dest="/etc/systemd/system/media-storage.mount"
+  template: src=ext4-mount.service.j2 dest="/etc/systemd/system/media-storage.mount"
   when: storagevol.changed
   
 # Specify XFS mount to startup with the node

--- a/roles/openstack-storage-volume/templates/ext4-mount.service.j2
+++ b/roles/openstack-storage-volume/templates/ext4-mount.service.j2
@@ -5,7 +5,7 @@ After=local-fs.target
  [Mount]
 What={{ storage_volume_dev }}
 Where=/media/storage
-Type=xfs
+Type=ext4
 Options=noatime
  
  [Install]

--- a/roles/openstack-system/tasks/main.yml
+++ b/roles/openstack-system/tasks/main.yml
@@ -22,6 +22,7 @@
     image: "{{ image }}"
     key_name: "{{ key_name }}"
     auto_ip: false
+    network: "{{ network_name }}"
 #    boot_volume: "{{ logical_cluster_name }}-{{ inventory_hostname }}-bootvol"
   register: os_host
 

--- a/roles/openstack-system/tasks/main.yml
+++ b/roles/openstack-system/tasks/main.yml
@@ -1,15 +1,15 @@
 ---
 
-- name: OpenStack system volume for "{{ logical_cluster_name }}-{{ inventory_hostname }}"
-  connection: local
-  become: false
-  os_volume:
-    state: present
-    wait: yes
-    display_name: "{{ logical_cluster_name }}-{{ inventory_hostname }}-bootvol"
-    image: "{{ image }}"
-    size: "{{ sys_vol_size }}"
-  register: os_host_sys_vol
+#- name: OpenStack system volume for "{{ logical_cluster_name }}-{{ inventory_hostname }}"
+#  connection: local
+#  become: false
+#  os_volume:
+#    state: present
+#    wait: yes
+#    display_name: "{{ logical_cluster_name }}-{{ inventory_hostname }}-bootvol"
+#    image: "{{ image }}"
+#    size: "{{ sys_vol_size }}"
+#  register: os_host_sys_vol
 
 - name: OpenStack System
   connection: local
@@ -19,9 +19,10 @@
     wait: yes
     name: "{{ logical_cluster_name }}-{{ inventory_hostname }}"
     flavor: "{{ flavor }}"
+    image: "{{ image }}"
     key_name: "{{ key_name }}"
     auto_ip: false
-    boot_volume: "{{ logical_cluster_name }}-{{ inventory_hostname }}-bootvol"
+#    boot_volume: "{{ logical_cluster_name }}-{{ inventory_hostname }}-bootvol"
   register: os_host
 
 #- debug: var=os_host

--- a/roles/openstack-system/tasks/main.yml
+++ b/roles/openstack-system/tasks/main.yml
@@ -1,17 +1,33 @@
 ---
 
-#- name: OpenStack system volume for "{{ logical_cluster_name }}-{{ inventory_hostname }}"
-#  connection: local
-#  become: false
-#  os_volume:
-#    state: present
-#    wait: yes
-#    display_name: "{{ logical_cluster_name }}-{{ inventory_hostname }}-bootvol"
-#    image: "{{ image }}"
-#    size: "{{ sys_vol_size }}"
-#  register: os_host_sys_vol
+- name: OpenStack system volume for "{{ logical_cluster_name }}-{{ inventory_hostname }}"
+  connection: local
+  become: false
+  os_volume:
+    state: present
+    wait: yes
+    display_name: "{{ logical_cluster_name }}-{{ inventory_hostname }}-bootvol"
+    image: "{{ image }}"
+    size: "{{ sys_vol_size }}"
+  register: os_host_sys_vol
+  when: site_name != "tacc"
 
-- name: OpenStack System
+- name: OpenStack System (volume backed instance)
+  connection: local
+  become: false
+  os_server:
+    state: present
+    wait: yes
+    name: "{{ logical_cluster_name }}-{{ inventory_hostname }}"
+    flavor: "{{ flavor }}"
+    key_name: "{{ key_name }}"
+    auto_ip: false
+    network: "{{ network_name }}"
+    boot_volume: "{{ logical_cluster_name }}-{{ inventory_hostname }}-bootvol"
+  register: os_host
+  when: site_name != "tacc"
+
+- name: OpenStack System (ephemeral instance)
   connection: local
   become: false
   os_server:
@@ -23,8 +39,8 @@
     key_name: "{{ key_name }}"
     auto_ip: false
     network: "{{ network_name }}"
-#    boot_volume: "{{ logical_cluster_name }}-{{ inventory_hostname }}-bootvol"
   register: os_host
+  when: site_name == "tacc"
 
 #- debug: var=os_host
 

--- a/roles/var-lib-docker/files/50-docker-depends-on-var-lib-docker.conf
+++ b/roles/var-lib-docker/files/50-docker-depends-on-var-lib-docker.conf
@@ -1,0 +1,5 @@
+# Dropin for docker.service
+
+[Unit]
+Requires=var-lib-docker.mount
+After=var-lib-docker.mount

--- a/roles/var-lib-docker/tasks/main.yml
+++ b/roles/var-lib-docker/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+
+- name: Dropin for Docker volume
+  become: true
+  copy: src=50-docker-depends-on-var-lib-docker.conf dest=/etc/systemd/system/docker.service.d/50-docker-depends-on-var-lib-docker.conf


### PR DESCRIPTION
* Removed bootvolume, since not supported by Jetstream
* Added role to override flannel MTU
* Updated handling for Docker MTU (which may actually not be needed at all)
* Added Docker log rotation
* Added systemd rule for Docker startup to depend on the /var/lib/docker mount
* Added site for TACC including MTU
* Added configmap and SMTP service